### PR TITLE
Set opener to null to prevent hijacking

### DIFF
--- a/jquery.newwindow.js
+++ b/jquery.newwindow.js
@@ -16,6 +16,7 @@
         $(this).click(function (e) {
           e.preventDefault();
           var newWindow = open(this.href);
+          newWindow.opener = null;
           options.open.call(newWindow, e);
         });
       });


### PR DESCRIPTION
This change prevents hijacking of the opening window location, as per: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/